### PR TITLE
Add "unit_of_measurement: W" to charging energy

### DIFF
--- a/custom_components/wattpilot/sensor.yaml
+++ b/custom_components/wattpilot/sensor.yaml
@@ -208,6 +208,7 @@ sensor:
     description: "Charging energy used for current car charging process"
     icon: "mdi:lightning-bolt-circle"
     device_class: power
+    unit_of_measurement: "W"
     value_id: 11
     attribute_ids:
       - L1_Voltage:0


### PR DESCRIPTION
this, in combination with a 'left' riemann sum allows adding the
consumption of the charger to an energy dashboard's "individual
devices" section