### PR TITLE
Fixed deprecation warnings and Charging Energy Sensor

### DIFF
--- a/custom_components/wattpilot/entities.py
+++ b/custom_components/wattpilot/entities.py
@@ -186,7 +186,7 @@ class ChargerPlatformEntity(Entity):
             default_model=GetChargerProp(self._charger,'typ',getattr(self._charger,'devicetype',STATE_UNKNOWN)),
             default_name=getattr(self._charger,'name',getattr(self._charger,'hostname',STATE_UNKNOWN)),
             sw_version=getattr(self._charger,'firmware',STATE_UNKNOWN),
-            configuration_url=getattr(self._charger,'url',STATE_UNKNOWN)
+            #configuration_url=getattr(self._charger,'url',STATE_UNKNOWN)
         )
         #_LOGGER.debug("%s - %s: device_info result: %s", self._charger_id, self._identifier, info)
         return info

--- a/custom_components/wattpilot/number.py
+++ b/custom_components/wattpilot/number.py
@@ -92,34 +92,34 @@ class ChargerNumber(ChargerPlatformEntity, NumberEntity):
     
     def _init_platform_specific(self):
         """Platform specific init actions"""
-        self._min=self._entity_cfg.get('min_value', None)
-        if not self._min is None:
-            self._min=float(self._min)
-        self._max=self._entity_cfg.get('max_value', None)
-        if not self._max is None:
-            self._max=float(self._max)
-        self._step=self._entity_cfg.get('step', None)
-        if not self._step is None:
-            self._step=float(self._step)
+        self._native_min=self._entity_cfg.get('native_min_value', None)
+        if not self._native_min is None:
+            self._native_min=float(self._native_min)
+        self._native_max=self._entity_cfg.get('native_max_value', None)
+        if not self._native_max is None:
+            self._native_max=float(self._native_max)
+        self._native_step=self._entity_cfg.get('native_step', None)
+        if not self._native_step is None:
+            self._native_step=float(self._native_step)
         self._mode=self._entity_cfg.get('mode', None)
 
 
     @property
-    def min_value(self) -> float | None:
+    def native_min_value(self) -> float | None:
         """Return the minimum accepted value (inclusive) for this entity."""
-        return self._min
+        return self._native_min
 
 
     @property
-    def max_value(self) -> float | None:
+    def native_max_value(self) -> float | None:
         """Return the maximum accepted value (inclusive) for this entity."""
-        return self._max
+        return self._native_max
 
 
     @property
-    def step(self) -> float | None:
+    def native_step(self) -> float | None:
         """Return the resolution of the values for this entity."""
-        return self._step
+        return self._native_step
 
 
     @property
@@ -128,12 +128,12 @@ class ChargerNumber(ChargerPlatformEntity, NumberEntity):
         return self._mode
 
 
-    async def async_set_value(self, value) -> None:
+    async def asyc_native_set_value(self, value) -> None:
         """Async: Change the current value."""
         try:
-            _LOGGER.debug("%s - %s: async_set_value: value was changed to: %s", self._charger_id, self._identifier, float)
+            _LOGGER.debug("%s - %s: asyc_native_set_value: value was changed to: %s", self._charger_id, self._identifier, float)
             if (self._identifier == 'fte'):
-                _LOGGER.debug("%s - %s: async_set_value: apply ugly workaround to always set next trip distance to kWH instead of KM", self._charger_id, self._identifier)
+                _LOGGER.debug("%s - %s: asyc_native_set_value: apply ugly workaround to always set next trip distance to kWH instead of KM", self._charger_id, self._identifier)
                 await async_SetChargerProp(self._charger,'esk',True)                 
             await async_SetChargerProp(self._charger,self._identifier,value,force_type=self._set_type)
         except Exception as e:

--- a/custom_components/wattpilot/number.yaml
+++ b/custom_components/wattpilot/number.yaml
@@ -11,9 +11,9 @@ number:
 #    name: <optional: name of the switch within HA>
 #    description: <optional: key within HA>
 #    icon: <optional: key within HA>
-#    min_value: <optional: the minimum accepted value>
-#    max_value: <optional: the maximum accepted value>
-#    step: <optional: Defines the resolution of the values, i.e. the smallest increment or decrement>
+#    native_min_value: <optional: the minimum accepted value>
+#    native_max_value: <optional: the maximum accepted value>
+#    native_step: <optional: Defines the resolution of the values, i.e. the smallest increment or decrement>
 #    mode: <optional: Defines how the number should be displayed in the UI. 'auto', 'box' or 'slider'
 #    enabled: <optional: if set to False entity is by default disabled>
 #    device_class: <optional: key within HA>
@@ -25,9 +25,9 @@ number:
     name: "Charging Power"
     description: "Charging range per Hour"
     icon: "mdi:car-electric"
-    min_value: 6.0
-    max_value: 16.0
-    step: 1.0
+    native_min_value: 6.0
+    native_max_value: 16.0
+    native_step: 1.0
     mode: slider
     device_class: current
 
@@ -36,9 +36,9 @@ number:
     name: "Max Price"
     description: "Lumina Strom/aWattar maximum price in cent"
     icon: "mdi:cash-100"
-    min_value: 0
-    max_value: 99999
-    step: 1
+    native_min_value: 0
+    native_max_value: 99999
+    native_step: 1
     entity_category: config
 
   - id: fmt
@@ -46,9 +46,9 @@ number:
     name: "Min Charging Time"
     description: "Minimum charging time after the charging has started"
     icon: "mdi:car-clock"
-    min_value: 30000
-    step: 30000
-    unit_of_measurement: "ms"
+    native_min_value: 30000
+    native_step: 30000
+    native_unit_of_measurement: "ms"
     entity_category: config
 
   - id: fst
@@ -56,9 +56,9 @@ number:
     name: "Start Chargig at"
     description: "PV Surplus start charging power"
     icon: "mdi:solar-power"
-    min_value: 1320
-    step: 1
-    unit_of_measurement: "W"
+    native_min_value: 1320
+    native_step: 1
+    native_unit_of_measurement: "W"
     device_class: power
     entity_category: config
 
@@ -67,9 +67,9 @@ number:
     name: "Next Trip Charging"
     description: "Defined amount of energy will be provided unitl the next scheduled ride"
     icon: "mdi:road-variant"
-    min_value: 100.0
-    max_value: 50000.0
-    step: 10.0
+    native_min_value: 100.0
+    native_max_value: 50000.0
+    native_step: 10.0
     device_class: energy
-    unit_of_measurement: "Wh"
+    native_unit_of_measurement: "Wh"
 

--- a/custom_components/wattpilot/sensor.yaml
+++ b/custom_components/wattpilot/sensor.yaml
@@ -208,6 +208,7 @@ sensor:
     description: "Charging energy used for current car charging process"
     icon: "mdi:lightning-bolt-circle"
     device_class: power
+    unit_of_measurement: W
     value_id: 11
     attribute_ids:
       - L1_Voltage:0


### PR DESCRIPTION
I made a fix to the charging energy sensor so that it will be recognized as a sensor correctly. I also fixed deprecation warnings which would make this component invalid from 2022.10 onwoards.