### PR TITLE
fix function name for async_set_native_value

### DIFF
--- a/custom_components/wattpilot/number.py
+++ b/custom_components/wattpilot/number.py
@@ -128,12 +128,12 @@ class ChargerNumber(ChargerPlatformEntity, NumberEntity):
         return self._mode
 
 
-    async def asyc_native_set_value(self, value) -> None:
+    async def async_set_native_value(self, value) -> None:
         """Async: Change the current value."""
         try:
-            _LOGGER.debug("%s - %s: asyc_native_set_value: value was changed to: %s", self._charger_id, self._identifier, float)
+            _LOGGER.debug("%s - %s: async_set_native_value: value was changed to: %s", self._charger_id, self._identifier, float)
             if (self._identifier == 'fte'):
-                _LOGGER.debug("%s - %s: asyc_native_set_value: apply ugly workaround to always set next trip distance to kWH instead of KM", self._charger_id, self._identifier)
+                _LOGGER.debug("%s - %s: async_set_native_value: apply ugly workaround to always set next trip distance to kWH instead of KM", self._charger_id, self._identifier)
                 await async_SetChargerProp(self._charger,'esk',True)                 
             await async_SetChargerProp(self._charger,self._identifier,value,force_type=self._set_type)
         except Exception as e:


### PR DESCRIPTION
There is a small typo in the function name. Due to this setting the charging power throws an exception:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 202, in handle_call_service
    await hass.services.async_call(
  File "/usr/src/homeassistant/homeassistant/core.py", line 1738, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1775, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 207, in handle_service
    await service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 678, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 931, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 715, in _handle_entity_call
    await result
  File "/usr/src/homeassistant/homeassistant/components/number/__init__.py", line 111, in async_set_value
    await entity.async_set_value(value)
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/number/__init__.py", line 417, in set_value
    raise NotImplementedError()
NotImplementedError
```

This can be fixed by renaming `asyc_native_set_value` to `async_set_native_value`.