### PR TITLE
Fix wrong naming of physical properties

### DIFF
--- a/custom_components/wattpilot/number.yaml
+++ b/custom_components/wattpilot/number.yaml
@@ -23,8 +23,8 @@ number:
 
   - id: amp
     set_type: int
-    name: "Charging Power"
-    description: "Charging range per Hour"
+    name: "Max Charging Current"
+    description: "Maximum charging current allowed per phase"
     icon: "mdi:car-electric"
     native_min_value: 6.0
     #native_max_value: 16.0 # different for 11KW vs 22KW model

--- a/custom_components/wattpilot/sensor.yaml
+++ b/custom_components/wattpilot/sensor.yaml
@@ -349,8 +349,8 @@ sensor:
 
   - source: property
     id: nrg
-    name: "Charging Energy"
-    description: "Charging energy used for current car charging process"
+    name: "Charging Power"
+    description: "Charging power used for current car charging process"
     icon: "mdi:lightning-bolt-circle"
     device_class: power
     unit_of_measurement: W


### PR DESCRIPTION
The entities `number.wattpilot_charging_power` and `sensor.wattpilot_charging_energy` both represent wrong physical properties. Changing them to `number.wattpilot_max_charging_current` and `sensor.wattpilot_charging_power` fixes this.