### PR TITLE
fix: async_forward_entry_setup creating log entry

### DIFF
--- a/custom_components/wattpilot/__init__.py
+++ b/custom_components/wattpilot/__init__.py
@@ -93,9 +93,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     try:
+        _LOGGER.debug("%s - async_setup_entry: Trigger setup for platforms", entry.entry_id)
         await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
     except Exception as e:
-        _LOGGER.error("%s - async_setup_entry: Setup trigger for platform %s failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
+        _LOGGER.error("%s - async_setup_entry: Setup trigger failed: %s (%s.%s)", entry.entry_id, str(e), e.__class__.__module__, type(e).__name__)
         return False
 
     try:

--- a/custom_components/wattpilot/__init__.py
+++ b/custom_components/wattpilot/__init__.py
@@ -93,9 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     try:
-        for platform in SUPPORTED_PLATFORMS:
-            _LOGGER.debug("%s - async_setup_entry: Trigger setup for platform: %s ", entry.entry_id, platform)
-            hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform))
+        await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
     except Exception as e:
         _LOGGER.error("%s - async_setup_entry: Setup trigger for platform %s failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
         return False


### PR DESCRIPTION
The logs state:


```
Detected that custom integration 'wattpilot' calls async_forward_entry_setup for integration, wattpilot with title: Wattpilot and entry_id: 01J24NP2FCC5C3BV3C7QX2V87W, which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead at custom_components/wattpilot/__init__.py, line 99: hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform)), please report it to the author of the 'wattpilot' custom integration
```

It looks like the call can be substituted with this one.

I tested it on my local installation and it seems fine 🤷 