### PR TITLE
Fix Inverter label showing as HMTL escaped characters

### DIFF
--- a/custom_components/wattpilot/sensor.py
+++ b/custom_components/wattpilot/sensor.py
@@ -7,6 +7,7 @@ import asyncio
 import aiofiles
 import yaml
 import os
+import html
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -91,12 +92,16 @@ class ChargerSensor(ChargerPlatformEntity, SensorEntity):
             self._attr_state_class= SensorStateClass((self._entity_cfg.get('state_class')).lower())
         if not self._entity_cfg.get('enum', None) is None:
            self._state_enum = dict(self._entity_cfg.get('enum', None))
-           
+        if not self._entity_cfg.get('html_escape', None) is None:
+           self._html_escape = True
+
     async def _async_update_validate_platform_state(self, state=None):
         """Async: Validate the given state for sensor specific requirements"""
         try:
             if state is None or state == 'None':
                 state = STATE_UNKNOWN
+            elif hasattr(self,'_html_escape') and self._html_escape:
+                state = html.unescape(state)
             elif not hasattr(self,'_state_enum'):
                 pass
             elif state in list(self._state_enum.keys()):

--- a/custom_components/wattpilot/sensor.yaml
+++ b/custom_components/wattpilot/sensor.yaml
@@ -24,6 +24,7 @@ sensor:
 #    variant: <optional string "11 / 22" to setup entity only if charger variant matches 11kW version or 22kW version>
 #    connection: <optional string "cloud / local" to setup entity only if charger connection type matches>
 #    default_state: <optional value to use as default state for "None"/"Null" charger properties - the default is STATE_UNKNOWN. Use with caution>
+#    html_escape: <optional boolean to escape HTML characters in state value>
 
   - source: attribute
     id: AccessState
@@ -213,6 +214,7 @@ sensor:
     icon: "mdi:solar-power"
     entity_category: diagnostic
     value_id: label
+    html_escape: True
     attribute_ids:
       - paired
       - model


### PR DESCRIPTION
Both Wattpilot python library and HA Wattpilot integration show Invert Name (cci.label) with HTML escaped characters. 

```
cci: {"id": "240.1315544", "paired": true, "deviceFamily": "DataManager", 
"label": "&#67;&#97;&#114;&#108;&#105;&#110;&#103;&#102;&#111;&#114;&#100;", 
"model": "WILMA2-O", "commonName": "", "ip": "192.168.86.8", "connected": true, 
"reachableMdns": false, "reachableUdp": true, "reachableHttp": true, "status": 0, "message": "ok"}
```

Label sould be **Carlingford**

As the wattpilot library itself is very abstracted, I believe addressing as such is a suitable fix for handling cci.label and any other property that maybe returned HTML escaped.