### PR TITLE
Update sensor.yaml to include state_class: measurement

### DIFF
--- a/custom_components/wattpilot/sensor.yaml
+++ b/custom_components/wattpilot/sensor.yaml
@@ -379,6 +379,7 @@ sensor:
     description: "Charging power used for current car charging process"
     icon: "mdi:lightning-bolt-circle"
     device_class: power
+    state_class: measurement
     unit_of_measurement: W
     default_state: -1
     value_id: 11


### PR DESCRIPTION
state_class: measurement is needed for the new 2025.12.0 energy dashboard to accept a power sensor, otherwise the entity is not available for selection.