### PR TITLE
Add binary sensor "Allow Charging"

### DIFF
--- a/custom_components/wattpilot/binary_sensor.py
+++ b/custom_components/wattpilot/binary_sensor.py
@@ -53,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     for entity_cfg in yaml_cfg[platform]:
         try:
+            entity_cfg['source'] = 'property'
             if not 'id' in entity_cfg or entity_cfg['id'] is None:
                 _LOGGER.error("%s - async_setup_entry %s: Invalid yaml configuration - no id: %s", entry.entry_id, platform, entity_cfg)
                 continue

--- a/custom_components/wattpilot/binary_sensor.py
+++ b/custom_components/wattpilot/binary_sensor.py
@@ -1,0 +1,101 @@
+"""Binary sensor entities for the Fronius Wattpilot integration."""
+
+from __future__ import annotations
+from typing import Final
+import logging
+import asyncio
+import aiofiles
+import yaml
+import os
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.binary_sensor import BinarySensorEntity
+
+from homeassistant.const import STATE_UNKNOWN
+
+from .entities import ChargerPlatformEntity
+
+from .const import (
+    CONF_CHARGER,
+    CONF_PUSH_ENTITIES,
+    DOMAIN,
+)
+
+_LOGGER: Final = logging.getLogger(__name__)
+platform='binary_sensor'
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the binary_sensor platform."""
+    _LOGGER.debug("Setting up %s platform entry: %s", platform, entry.entry_id)
+    entites=[]
+    try:
+        _LOGGER.debug("%s - async_setup_entry %s: Reading static yaml configuration", entry.entry_id, platform)
+        async with aiofiles.open(os.path.dirname(os.path.realpath(__file__))+'/'+platform+'.yaml', 'r') as y:
+            yaml_cfg=yaml.safe_load(await y.read())
+    except Exception as e:
+        _LOGGER.error("%s - async_setup_entry %s: Reading static yaml configuration failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
+        return False
+
+    try:
+        _LOGGER.debug("%s - async_setup_entry %s: Getting charger instance from data store", entry.entry_id, platform)
+        charger=hass.data[DOMAIN][entry.entry_id][CONF_CHARGER]
+    except Exception as e:
+        _LOGGER.error("%s - async_setup_entry %s: Getting charger instance from data store failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
+        return False
+
+    try:
+        _LOGGER.debug("%s - async_setup_entry %s: Getting push entities dict from data store", entry.entry_id, platform)
+        push_entities=hass.data[DOMAIN][entry.entry_id][CONF_PUSH_ENTITIES]
+    except Exception as e:
+        _LOGGER.error("%s - async_setup_entry %s: Getting push entities dict from data store failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
+        return False
+
+    for entity_cfg in yaml_cfg[platform]:
+        try:
+            if not 'id' in entity_cfg or entity_cfg['id'] is None:
+                _LOGGER.error("%s - async_setup_entry %s: Invalid yaml configuration - no id: %s", entry.entry_id, platform, entity_cfg)
+                continue
+            elif not 'source' in entity_cfg or entity_cfg['source'] is None:
+                _LOGGER.error("%s - async_setup_entry %s: Invalid yaml configuration - no source: %s", entry.entry_id, platform, entity_cfg)
+                continue
+            entity=ChargerBinarySensor(hass, entry, entity_cfg, charger)
+            if getattr(entity,'_init_failed', True): continue
+            entites.append(entity)
+            if entity._source == 'property':
+                push_entities[entity._identifier]=entity
+            await asyncio.sleep(0)
+        except Exception as e:
+            _LOGGER.error("%s - async_setup_entry %s: Reading static yaml configuration failed: %s (%s.%s)", entry.entry_id, platform, str(e), e.__class__.__module__, type(e).__name__)
+            return False
+
+    _LOGGER.info("%s - async_setup_entry: setup %s %s entities", entry.entry_id, len(entites), platform)
+    if not entites:
+        return None
+    async_add_entities(entites)
+
+
+class ChargerBinarySensor(ChargerPlatformEntity, BinarySensorEntity):
+    """Binary sensor class for Fronius Wattpilot integration."""
+    _state_attr='_attr_is_on'
+
+
+    async def _async_update_validate_platform_state(self, state=None):
+        """Async: Validate the given state for binary_sensor specific requirements"""
+        try:
+            if state is None or state == 'None':
+                state = STATE_UNKNOWN
+            elif isinstance(state, bool):
+                pass
+            elif str(state).lower() in [ 'true', 'on', '1' ]:
+                state = True
+            elif str(state).lower() in [ 'false', 'off', '0' ]:
+                state = False
+            else:
+                _LOGGER.warning("%s - %s: _async_update_validate_platform_state failed: state %s not valid for binary_sensor platform", self._charger_id, self._identifier, state)
+                return None
+
+            return state
+        except Exception as e:
+            _LOGGER.error("%s - %s: _async_update_validate_platform_state failed: %s (%s.%s)", self._charger_id, self._identifier, str(e), e.__class__.__module__, type(e).__name__)
+            return None

--- a/custom_components/wattpilot/binary_sensor.yaml
+++ b/custom_components/wattpilot/binary_sensor.yaml
@@ -1,0 +1,10 @@
+# version: 2026.07.26
+# author: David Freina, david@freina.at
+# description: YAML configuration file - holding predefined entities
+#   see: https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-de.md
+
+binary_sensor:
+  - id: alw
+    name: "Allow Charging"
+    description: "Is the car allowed to charge at all now?"
+    icon: "mdi:ev-station"

--- a/custom_components/wattpilot/const.py
+++ b/custom_components/wattpilot/const.py
@@ -6,7 +6,7 @@ from typing import Final
 DOMAIN: Final = 'wattpilot'
 FUNC_OPTION_UPDATES: Final = 'options_update_listener'
 FUNC_PROPERTY_UPDATES_CALLBACK: Final = 'property_updates_callback'
-SUPPORTED_PLATFORMS: Final = ["button", "number", "select", "sensor", "switch", "update"]
+SUPPORTED_PLATFORMS: Final = ["binary_sensor", "button", "number", "select", "sensor", "switch", "update"]
 
 DEFAULT_NAME: Final = 'Wattpilot'
 CONF_DBG_PROPS: Final = 'debug_properties'


### PR DESCRIPTION
## Summary

Adds a `binary_sensor` platform and exposes the go-e [`alw`](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-de.md#:~:text=alw,laden) ("Allow Charging") property as an on/off entity.
The property was removed in #8 because it was used wrong and then never readded.

## Changes

- `const.py` - register the new `binary_sensor` platform.
- `binary_sensor.py` / `binary_sensor.yaml` *(new)* - read-only entity for `alw`

## Testing

Verified on a Wattpilot (fw 42.5) over WebSocket: allow state changes according to enable/stop charging (force-stop → `off`, force-on → `on`).