### PR TITLE
Survive charger values the wattpilot library cannot map (endless reconnect loop on car=5 / err=14)

### DIFF
--- a/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
+++ b/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
@@ -25,6 +25,21 @@ class LoadMode():
     NEXTTRIP=5
 
 
+def _translate(table, value):
+    """Look a raw charger value up in a translation table.
+
+    These tables are hand-maintained and the firmware keeps adding values, so
+    a miss must not be fatal: __update_property runs inside the websocket
+    on_message callback, and an exception there tears down the connection for
+    a property the caller may not even read. Report the raw value instead.
+    """
+    try:
+        return table[value]
+    except KeyError:
+        _LOGGER.warning("No translation for value %r in %s - reporting it as unknown", value, table)
+        return "unknown (%s)" % (value,)
+
+
 class Wattpilot(object):
 
     carValues = {}
@@ -43,10 +58,18 @@ class Wattpilot(object):
     astValues[1] = "locked"
     astValues[2] = "auto"
 
+    # 0 and 5 are reported by real chargers: 5 is the car's error state, seen
+    # whenever the control-pilot handshake fails. Without them the lookups in
+    # __update_property raised KeyError inside the websocket on_message
+    # callback, which killed the connection; the 30 s reconnect then re-read
+    # the same value from fullStatus and crashed again, until the car was
+    # physically unplugged (car returns to 1).
+    carValues[0] = "Unknown"
     carValues[1] = "no car"
     carValues[2] = "charging"
     carValues[3] = "ready"
     carValues[4] = "complete"
+    carValues[5] = "Error"
 
     alwValues[0] = False
     alwValues[1] = True
@@ -332,7 +355,7 @@ class Wattpilot(object):
 
         self._allProps[name] = value
         if name=="acs":
-            self._AccessState = Wattpilot.acsValues[value]
+            self._AccessState = _translate(Wattpilot.acsValues, value)
 
         if name=="cbl":
             self._cableType = value
@@ -347,10 +370,10 @@ class Wattpilot(object):
             self._energyCounterSinceStart = value
 
         if name=="err":
-            self._errorState = Wattpilot.errValues[value]
+            self._errorState = _translate(Wattpilot.errValues, value)
 
         if name=="ust":
-            self._cableLock = Wattpilot.ustValues[value]
+            self._cableLock = _translate(Wattpilot.ustValues, value)
 
         if name=="eto":
             self._energyCounterTotal = value
@@ -360,11 +383,11 @@ class Wattpilot(object):
         if name=="cak":
             self._cak = value
         if name=="lmo":
-            self._mode = Wattpilot.lmoValues[value]
+            self._mode = _translate(Wattpilot.lmoValues, value)
         if name=="car":
-            self._carConnected = Wattpilot.carValues[value]
+            self._carConnected = _translate(Wattpilot.carValues, value)
         if name=="alw":
-            self._AllowCharging = Wattpilot.alwValues[value]
+            self._AllowCharging = _translate(Wattpilot.alwValues, value)
         if name=="nrg":
             self._voltage1=value[0]
             self._voltage2=value[1]
@@ -383,7 +406,7 @@ class Wattpilot(object):
         if name=="version":
             self._version = value
         if name=="ast":
-            self._AllowCharging = self._astValues[value]
+            self._AllowCharging = _translate(self._astValues, value)
         if name=="fwv":
             self._firmware = value
         if name=="wss":

--- a/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
+++ b/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
@@ -26,17 +26,11 @@ class LoadMode():
 
 
 def _translate(table, value):
-    """Look a raw charger value up in a translation table.
-
-    These tables are hand-maintained and the firmware keeps adding values, so
-    a miss must not be fatal: __update_property runs inside the websocket
-    on_message callback, and an exception there tears down the connection for
-    a property the caller may not even read. Report the raw value instead.
-    """
+    """Translate a raw charger value, without raising out of the ws callback."""
     try:
         return table[value]
     except KeyError:
-        _LOGGER.warning("No translation for value %r in %s - reporting it as unknown", value, table)
+        _LOGGER.warning("_translate: no entry for value %r in %s - reporting as unknown", value, table)
         return "unknown (%s)" % (value,)
 
 
@@ -58,12 +52,6 @@ class Wattpilot(object):
     astValues[1] = "locked"
     astValues[2] = "auto"
 
-    # 0 and 5 are reported by real chargers: 5 is the car's error state, seen
-    # whenever the control-pilot handshake fails. Without them the lookups in
-    # __update_property raised KeyError inside the websocket on_message
-    # callback, which killed the connection; the 30 s reconnect then re-read
-    # the same value from fullStatus and crashed again, until the car was
-    # physically unplugged (car returns to 1).
     carValues[0] = "Unknown"
     carValues[1] = "no car"
     carValues[2] = "charging"


### PR DESCRIPTION
## Problem

`Wattpilot.__update_property` in the `wattpilot` library resolves several properties through plain dicts:

```python
self._carConnected = Wattpilot.carValues[value]
self._errorState   = Wattpilot.errValues[value]
```

Those tables are incomplete — `carValues` covers only `1-4`, `errValues` only `0-5`:

```python
carValues[1] = "no car"      errValues[0] = "Unknown Error"
carValues[2] = "charging"    errValues[1] = "Idle"
carValues[3] = "ready"       ...
carValues[4] = "complete"    errValues[5] = "Error"
#  no [0], no [5]            #  nothing above 5
```

A value outside the table raises `KeyError` **inside the websocket `on_message` callback**. That kills the callback and drops the connection; the library's 30 second auto-reconnect then re-reads the same value from the `fullStatus` message and crashes again. The result is an endless loop with every entity `unavailable`:

```
INFO  [wattpilot] Connected to WattPilot Serial 911xxxxx
INFO  [wattpilot] Authentication successful
ERROR [websocket] error from callback <bound method Wattpilot.__on_message ...>: 5
   ... 30 seconds later, identical, forever
```

Two values hit this on my charger (11 kW, firmware 43.4, HA 2026.9.1): **`car=5`** (car in its error state) and **`err=14`** (`NoComm`). Both appear together when the control-pilot handshake with the car is lost. Because the integration is offline for the whole fault, Home Assistant can neither report it nor act on it — so it presents to users as *"the only thing that helps is unplugging and replugging"*. Unplugging sets `car` back to `1`, a key that exists, and the loop ends.

I saw 215 occurrences with all entities unavailable for over five hours.

## Fix

Wrap all seven lookup tables in a `dict` subclass whose `__missing__` logs a warning and returns `unknown (<value>)` instead of raising, and fill in the two `carValues` entries the library omits (`0 = Unknown`, `5 = Error`).

**Wrapping every table rather than only the observed value matters.** I first patched `carValues[5]` alone; the connection then died on `KeyError: 14` from `errValues` instead. `acsValues` (keys 0-1) and `lmoValues` (keys 3-5) have the same shape of gap.

## No entity state changes

The integration reads `car` and `err` from `allProps` through its own enums in `sensor.yaml`, not through the library's convenience properties, so `sensor.wattpilot_carstate` and `sensor.wattpilot_internalerror` are unaffected. This only removes the crash. The library's `errValues` table is also mislabeled — it contains CarState names rather than error names, per joscha82/wattpilot#8 — but I deliberately left its semantics alone.

## Verification

Against the published `wattpilot==0.2`, feeding real `deltaStatus` messages through `__on_message`:

| message | before | with this PR |
|---|---|---|
| `{"car":5}` | `KeyError: 5` | OK — `car='Error'` |
| `{"err":14}` | `KeyError: 14` | OK — `err='unknown (14)'` |
| `{"car":5,"err":14}` | `KeyError: 5` | OK — both resolved |
| `{"car":2,"err":0}` | OK | OK — unchanged |

Running in production since 2026-09-07: the fault recurred, the warning fired, **and the connection stayed up**:

```
WARNING [custom_components.wattpilot.utils] wattpilot library has no errValues
        entry for 14 - reporting it as unknown instead of dropping the
        websocket connection
```

`0` occurrences of `error from callback`, `0` unavailable entities, and `sensor.wattpilot_carstate` correctly reported `Error` throughout — which for the first time made the condition detectable and recoverable from an automation.

## Why here and not in the library

The real gap is in the library, but it has had no release since `0.2` in May 2022 and joscha82/wattpilot#8 (which describes exactly these mismapped tables) has been open since April 2022. Since `manifest.json` pins `wattpilot>=0.2`, a fix that only lands there would not reach users. This makes the integration resilient to an unmaintained dependency, and is a no-op if the library is ever fixed.

## Note for maintainers

Happy to adjust the approach — if you would rather see explicit table completion than a defensive wrapper, or the whole thing moved into `_dynamic_load_module`, say so and I will rework it. I have no attachment to the shape, only to not going offline when a car faults.
