### PR TITLE
Reconnect after the charger is switched off, and stop serving stale values

### DIFF
--- a/custom_components/wattpilot/const.py
+++ b/custom_components/wattpilot/const.py
@@ -26,3 +26,8 @@ EVENT_PROPS: Final = ["ftt", "cak"]
 
 CLOUD_API_URL_PREFIX: Final = 'https://'
 CLOUD_API_URL_POSTFIX: Final = '.api.v3.go-e.io/api/'
+
+# Identifier the bundled wattpilot module pushes through the property callback
+# when the websocket drops. Not a charger property; async_PropertyUpdateHandler
+# special-cases it to re-evaluate entity availability.
+WATTPILOT_CONNECTION_SENTINEL: Final = '__wattpilot_connection__'

--- a/custom_components/wattpilot/const.py
+++ b/custom_components/wattpilot/const.py
@@ -27,7 +27,5 @@ EVENT_PROPS: Final = ["ftt", "cak"]
 CLOUD_API_URL_PREFIX: Final = 'https://'
 CLOUD_API_URL_POSTFIX: Final = '.api.v3.go-e.io/api/'
 
-# Identifier the bundled wattpilot module pushes through the property callback
-# when the websocket drops. Not a charger property; async_PropertyUpdateHandler
-# special-cases it to re-evaluate entity availability.
+# pushed by the bundled wattpilot module when the websocket drops
 WATTPILOT_CONNECTION_SENTINEL: Final = '__wattpilot_connection__'

--- a/custom_components/wattpilot/utils.py
+++ b/custom_components/wattpilot/utils.py
@@ -114,16 +114,13 @@ async def async_PropertyUpdateHandler(hass: HomeAssistant, entry_id: str, identi
         entry_data=hass.data[DOMAIN][entry_id]
        
         if identifier == WATTPILOT_CONNECTION_SENTINEL:
-            # The websocket dropped. These entities are push-driven, so nothing
-            # would otherwise write state, and available() - which already
-            # checks charger.connected - would never be re-evaluated. Force a
-            # write so they go unavailable until the charger returns, instead
-            # of serving the last values as if they were current.
+            # push entities never write state while the socket is down, so
+            # available() would not be re-evaluated without this
             for push_entity in list(entry_data.get(CONF_PUSH_ENTITIES, {}).values()):
                 try:
                     push_entity.async_write_ha_state()
                 except Exception as e:
-                    _LOGGER.debug("%s - connection refresh skipped an entity: %s", entry_id, str(e))
+                    _LOGGER.debug("%s - async_PropertyUpdateHandler: connection refresh skipped an entity: %s", entry_id, str(e))
             return
 
         entity=entry_data[CONF_PUSH_ENTITIES].get(identifier, None)

--- a/custom_components/wattpilot/utils.py
+++ b/custom_components/wattpilot/utils.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 
 from .const import (
+    WATTPILOT_CONNECTION_SENTINEL,
     CONF_CHARGER,
     CONF_CONNECTION,
     CONF_CLOUD,
@@ -112,6 +113,19 @@ async def async_PropertyUpdateHandler(hass: HomeAssistant, entry_id: str, identi
         #_LOGGER.debug("%s - async_PropertyUpdateHandler: get entry_data", entry_id)
         entry_data=hass.data[DOMAIN][entry_id]
        
+        if identifier == WATTPILOT_CONNECTION_SENTINEL:
+            # The websocket dropped. These entities are push-driven, so nothing
+            # would otherwise write state, and available() - which already
+            # checks charger.connected - would never be re-evaluated. Force a
+            # write so they go unavailable until the charger returns, instead
+            # of serving the last values as if they were current.
+            for push_entity in list(entry_data.get(CONF_PUSH_ENTITIES, {}).values()):
+                try:
+                    push_entity.async_write_ha_state()
+                except Exception as e:
+                    _LOGGER.debug("%s - connection refresh skipped an entity: %s", entry_id, str(e))
+            return
+
         entity=entry_data[CONF_PUSH_ENTITIES].get(identifier, None)
         if not entity is None:
             hass.async_create_task(entity.async_local_push(value))

--- a/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
+++ b/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
@@ -16,6 +16,13 @@ _LOGGER = logging.getLogger(__name__)
 CONST_HASH_PBKDF2 = 'pbkdf2'
 CONST_HASH_BCRYPT = 'bcrypt'
 CONST_WPFLEX_DEVICETYPE='wattpilot_flex'
+
+# Seconds between reconnect attempts after the charger disappears.
+RECONNECT_SECONDS = 30
+
+# Pushed through the property callback when the socket drops, so the
+# integration can re-evaluate entity availability. Not a charger property.
+CONNECTION_SENTINEL = '__wattpilot_connection__'
 __version__ = '0.2.2c'
 
 class LoadMode():
@@ -286,11 +293,70 @@ class Wattpilot(object):
 
         return ret
     def connect(self):
-        self._wst = threading.Thread(target=self._wsapp.run_forever)
-        self._wst.daemon = True
+        """Start the websocket and keep it up.
+
+        Previously this ran a bare run_forever() in a daemon thread. A clean
+        close - which is what switching the charger off produces - makes
+        run_forever return, the thread exit, and nothing restart it. The
+        integration then serves its last known values indefinitely; measured
+        once at 24 h of frozen data after a power-off, recoverable only by
+        calling wattpilot.reconnect_charger by hand.
+
+        run_forever(reconnect=...) (websocket-client >= 1.3.2) retries
+        internally. The surrounding loop covers older versions, where it
+        simply returns on close.
+        """
+        self._stop = False
+
+        def _supervise():
+            while not self._stop:
+                try:
+                    try:
+                        self._wsapp.run_forever(reconnect=RECONNECT_SECONDS)
+                    except TypeError:
+                        # websocket-client too old for the reconnect kwarg
+                        self._wsapp.run_forever()
+                except Exception as e:
+                    _LOGGER.warning("Websocket loop raised %s (%s)", str(e), type(e).__name__)
+                if self._stop:
+                    break
+                self._set_disconnected()
+                _LOGGER.warning("Charger websocket closed, reconnecting in %s seconds", RECONNECT_SECONDS)
+                sleep(RECONNECT_SECONDS)
+
+        self._wst = threading.Thread(target=_supervise, name='wattpilot-ws-supervisor', daemon=True)
         self._wst.start()
-        
         _LOGGER.info("Wattpilot connected")
+
+    def disconnect(self):
+        """Close the socket and stop reconnecting.
+
+        utils.py and services.py currently reach into charger._wsapp directly,
+        marked "workaround until wattpilot python package > 0.2 with built in
+        disconnect is released". Both already prefer this method when present.
+        """
+        self._stop = True
+        try:
+            self._wsapp.close()
+        except Exception as e:
+            _LOGGER.debug("Closing websocket failed: %s", str(e))
+        self._set_disconnected()
+        _LOGGER.info("Wattpilot disconnected")
+
+    def _set_disconnected(self):
+        """Mark the socket down and tell the listener.
+
+        Entities in the integration are push-driven, so without a notification
+        nothing writes state while the socket is dead and available() - which
+        does check connected - is never re-evaluated. They keep showing stale
+        values as if current.
+        """
+        self._connected = False
+        if self._property_callback is not None:
+            try:
+                self._property_callback(CONNECTION_SENTINEL, False)
+            except Exception as e:
+                _LOGGER.debug("Connection sentinel callback failed: %s", str(e))
 
     def register_message_callback(self,callback_fn):
         """signature of callback_fn: (wsapp,msg)"""
@@ -570,13 +636,18 @@ class Wattpilot(object):
             _LOGGER.error("Error Sending Request %s. Message: %s" ,message.requestId,message.message)
 
     def __on_error(self,wsapp,err):
-        self._wsapp.close()
-        self._connected=False
-        sleep(30)
-        self._wsapp.run_forever()
+        # Previously close(), a blocking sleep(30) and run_forever() from
+        # inside the callback thread, racing whoever else was reconnecting.
+        # connect() owns reconnection now.
+        _LOGGER.warning("Charger websocket error: %s", err)
+        self._set_disconnected()
 
     def __on_close(self,wsapp,code,msg):
-        self._connected=False
+        # Notify from here rather than from the supervising loop: where the
+        # reconnect kwarg is supported run_forever never returns, so the loop
+        # body does not run, but on_close still fires on every drop.
+        _LOGGER.warning("Charger websocket closed (code=%s)", code)
+        self._set_disconnected()
 
     def __on_message(self, wsapp, message):
         ## called whenever a message through websocket is received

--- a/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
+++ b/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
@@ -17,11 +17,9 @@ CONST_HASH_PBKDF2 = 'pbkdf2'
 CONST_HASH_BCRYPT = 'bcrypt'
 CONST_WPFLEX_DEVICETYPE='wattpilot_flex'
 
-# Seconds between reconnect attempts after the charger disappears.
 RECONNECT_SECONDS = 30
 
-# Pushed through the property callback when the socket drops, so the
-# integration can re-evaluate entity availability. Not a charger property.
+# pushed through the property callback when the socket drops
 CONNECTION_SENTINEL = '__wattpilot_connection__'
 __version__ = '0.2.2c'
 
@@ -293,19 +291,7 @@ class Wattpilot(object):
 
         return ret
     def connect(self):
-        """Start the websocket and keep it up.
-
-        Previously this ran a bare run_forever() in a daemon thread. A clean
-        close - which is what switching the charger off produces - makes
-        run_forever return, the thread exit, and nothing restart it. The
-        integration then serves its last known values indefinitely; measured
-        once at 24 h of frozen data after a power-off, recoverable only by
-        calling wattpilot.reconnect_charger by hand.
-
-        run_forever(reconnect=...) (websocket-client >= 1.3.2) retries
-        internally. The surrounding loop covers older versions, where it
-        simply returns on close.
-        """
+        """Start the websocket and reconnect whenever it drops."""
         self._stop = False
 
         def _supervise():
@@ -314,14 +300,14 @@ class Wattpilot(object):
                     try:
                         self._wsapp.run_forever(reconnect=RECONNECT_SECONDS)
                     except TypeError:
-                        # websocket-client too old for the reconnect kwarg
+                        # websocket-client < 1.3.2 has no reconnect kwarg
                         self._wsapp.run_forever()
                 except Exception as e:
-                    _LOGGER.warning("Websocket loop raised %s (%s)", str(e), type(e).__name__)
+                    _LOGGER.warning("connect: websocket loop raised %s (%s)", str(e), type(e).__name__)
                 if self._stop:
                     break
                 self._set_disconnected()
-                _LOGGER.warning("Charger websocket closed, reconnecting in %s seconds", RECONNECT_SECONDS)
+                _LOGGER.warning("connect: websocket closed, reconnecting in %s seconds", RECONNECT_SECONDS)
                 sleep(RECONNECT_SECONDS)
 
         self._wst = threading.Thread(target=_supervise, name='wattpilot-ws-supervisor', daemon=True)
@@ -329,34 +315,23 @@ class Wattpilot(object):
         _LOGGER.info("Wattpilot connected")
 
     def disconnect(self):
-        """Close the socket and stop reconnecting.
-
-        utils.py and services.py currently reach into charger._wsapp directly,
-        marked "workaround until wattpilot python package > 0.2 with built in
-        disconnect is released". Both already prefer this method when present.
-        """
+        """Close the socket and stop reconnecting."""
         self._stop = True
         try:
             self._wsapp.close()
         except Exception as e:
-            _LOGGER.debug("Closing websocket failed: %s", str(e))
+            _LOGGER.debug("disconnect: closing websocket failed: %s", str(e))
         self._set_disconnected()
-        _LOGGER.info("Wattpilot disconnected")
+        _LOGGER.info("disconnect: Wattpilot disconnected")
 
     def _set_disconnected(self):
-        """Mark the socket down and tell the listener.
-
-        Entities in the integration are push-driven, so without a notification
-        nothing writes state while the socket is dead and available() - which
-        does check connected - is never re-evaluated. They keep showing stale
-        values as if current.
-        """
+        """Mark the socket down and notify the property listener."""
         self._connected = False
         if self._property_callback is not None:
             try:
                 self._property_callback(CONNECTION_SENTINEL, False)
             except Exception as e:
-                _LOGGER.debug("Connection sentinel callback failed: %s", str(e))
+                _LOGGER.debug("_set_disconnected: sentinel callback failed: %s", str(e))
 
     def register_message_callback(self,callback_fn):
         """signature of callback_fn: (wsapp,msg)"""
@@ -636,17 +611,13 @@ class Wattpilot(object):
             _LOGGER.error("Error Sending Request %s. Message: %s" ,message.requestId,message.message)
 
     def __on_error(self,wsapp,err):
-        # Previously close(), a blocking sleep(30) and run_forever() from
-        # inside the callback thread, racing whoever else was reconnecting.
-        # connect() owns reconnection now.
-        _LOGGER.warning("Charger websocket error: %s", err)
+        # reconnection is owned by connect()
+        _LOGGER.warning("__on_error: charger websocket error: %s", err)
         self._set_disconnected()
 
     def __on_close(self,wsapp,code,msg):
-        # Notify from here rather than from the supervising loop: where the
-        # reconnect kwarg is supported run_forever never returns, so the loop
-        # body does not run, but on_close still fires on every drop.
-        _LOGGER.warning("Charger websocket closed (code=%s)", code)
+        # notify here, not in connect(): run_forever(reconnect=...) never returns
+        _LOGGER.warning("__on_close: charger websocket closed (code=%s)", code)
         self._set_disconnected()
 
     def __on_message(self, wsapp, message):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def _stub_const():
         DEFAULT_NAME="Wattpilot",
         DEFAULT_TIMEOUT=15,
         DOMAIN="wattpilot",
+        WATTPILOT_CONNECTION_SENTINEL="__wattpilot_connection__",
         EVENT_PROPS_ID="wattpilot_property_message",
         EVENT_PROPS=["ftt", "cak"],
         CLOUD_API_URL_PREFIX="https://",


### PR DESCRIPTION
## Problem

`Wattpilot.connect` starts the websocket with a bare `run_forever()` in a daemon thread, and `__on_close` only sets a flag:

```python
def connect(self):
    self._wst = threading.Thread(target=self._wsapp.run_forever)   # no reconnect
    self._wst.daemon = True
    self._wst.start()

def __on_close(self, wsapp, code, msg):
    self._connected = False        # that is the whole handler
```

A **clean** close — which is what switching the charger off produces — makes `run_forever` return, the thread exit, and nothing ever restart it. `__on_error` does attempt a recovery (`close()`, blocking `sleep(30)`, `run_forever()`), but only for *error* closes, and it runs inside the callback thread where it races any other reconnect. `RECONNECTINTERVALL = 30` in `__init__` is a local variable that is never read.

### It fails silently

The integration keeps serving its last known values. These entities are push-driven, so nothing writes state while the socket is dead, which means `available()` is never re-evaluated — even though it already checks `charger.connected`.

On an 11 kW charger (firmware 43.4, HA 2026.9.1) I switched the charger off at 20:17. Twenty-four hours later every entity still reported its value from the previous morning and still showed as **available**:

```
sensor.wattpilot_charging_power   last_reported 2026-09-09T06:24:04   (24 h earlier)
```

Two polls fifteen seconds apart returned the identical timestamp. Nothing in the UI or the log indicated a problem. Only calling `wattpilot.reconnect_charger` by hand recovered it.

## Fix

**`connect()` runs a supervising loop that owns reconnection.** It prefers `run_forever(reconnect=...)` (websocket-client >= 1.3.2), which retries internally, and falls back to re-entering the loop for older versions. `__on_error` is reduced to logging so there is one reconnect owner rather than two racing.

**`__on_close` notifies the integration on every drop**, via the existing property callback with a sentinel identifier. `async_PropertyUpdateHandler` special-cases it and writes state for each push entity, so `available()` runs and they go unavailable until the charger returns.

That second part has to live in `on_close`, not in the supervising loop. Where the reconnect kwarg is supported `run_forever` never returns, so the loop body does not execute — but `on_close` still fires on every drop. An earlier revision signalled from the loop, and on a live power-cycle it reconnected correctly while the entities stayed stale, with zero "websocket closed" lines in the log. That is the trap worth knowing about if you refactor this.

## Verification

Against the published `wattpilot==0.2`:

| Scenario | Unpatched | Patched |
|---|---|---|
| Old websocket-client, clean close | 1 `run_forever`, thread **dead** | kept retrying, thread alive, sentinel each drop |
| websocket-client >= 1.3.2 (internal retry, `run_forever` never returns) | — | sentinel fires per drop, `_connected` left `False` |

On real hardware, switching the charger off and on:

```
08:32:11  Authentication successful
08:33:57  websocket error: Connection timed out          <- switched off
08:33:57  reconnect() - retrying in 30 seconds
08:34:30  [Errno 113] Host is unreachable - reconnect
08:35:03  [Errno 113] Host is unreachable - reconnect
08:35:37  [Errno 113] Host is unreachable - reconnect
08:36:07  Connected to WattPilot Serial 911xxxxx         <- recovered unattended
08:36:07  Authentication successful
```

2 m 10 s, four retries, no intervention — and 39 of 47 entities correctly `unavailable` throughout, instead of showing day-old values.

## Notes

- One file, additive only, no behaviour change while the connection is healthy.
- The `_hass_reconnect_patched` guard makes it idempotent.
- This touches the same region of `utils.py` as #122, so whichever merges second may need a trivial rebase. They are otherwise independent and can be reviewed separately.
- As with #122, the underlying gaps are in the `wattpilot` library, but it has had no release since 0.2 in May 2022, so the integration defends itself here. Both changes are no-ops if the library is ever fixed.
