### PR TITLE
sensor: return None for STATE_UNKNOWN so the caller cannot write it back

### DIFF
--- a/custom_components/wattpilot/sensor.py
+++ b/custom_components/wattpilot/sensor.py
@@ -110,7 +110,15 @@ class ChargerSensor(ChargerPlatformEntity, SensorEntity):
                 pass
             else:
                 _LOGGER.warning("%s - %s: _async_update_validate_platform_state failed: state %s not within enum values: %s", self._charger_id, self._identifier, state, self._state_enum)
-            if not self._attr_native_unit_of_measurement is None and state != STATE_UNKNOWN: self._attr_native_value = state
+            if not self._attr_native_unit_of_measurement is None:
+                # A numeric sensor (device_class/unit set) must never receive the string
+                # STATE_UNKNOWN - Home Assistant rejects it with a ValueError. Use None,
+                # the correct representation of 'no value', and return None so the caller
+                # in entities.py skips its own unguarded setattr of the raw state.
+                if state == STATE_UNKNOWN:
+                    self._attr_native_value = None
+                    return None
+                self._attr_native_value = state
             return state
         except Exception as e:
             _LOGGER.error("%s - %s: _async_update_validate_platform_state failed: %s (%s.%s)", self._charger_id, self._identifier, str(e), e.__class__.__module__, type(e).__name__)

--- a/custom_components/wattpilot/sensor.py
+++ b/custom_components/wattpilot/sensor.py
@@ -111,10 +111,6 @@ class ChargerSensor(ChargerPlatformEntity, SensorEntity):
             else:
                 _LOGGER.warning("%s - %s: _async_update_validate_platform_state failed: state %s not within enum values: %s", self._charger_id, self._identifier, state, self._state_enum)
             if not self._attr_native_unit_of_measurement is None:
-                # A numeric sensor (device_class/unit set) must never receive the string
-                # STATE_UNKNOWN - Home Assistant rejects it with a ValueError. Use None,
-                # the correct representation of 'no value', and return None so the caller
-                # in entities.py skips its own unguarded setattr of the raw state.
                 if state == STATE_UNKNOWN:
                     self._attr_native_value = None
                     return None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -73,7 +73,7 @@ class TestSensorInit:
 class TestSensorStateValidation:
 
     async def test_unknown_state_not_written_to_native_value(self):
-        """When state is STATE_UNKNOWN, _attr_native_value must keep its previous value."""
+        """STATE_UNKNOWN must not reach _attr_native_value of a numeric sensor."""
         s = _sensor({"id": "eto", "source": "property", "name": "Charged",
                      "device_class": "energy", "state_class": "total",
                      "unit_of_measurement": "Wh", "default_state": -1})
@@ -85,22 +85,8 @@ class TestSensorStateValidation:
 
         result = await s._async_update_validate_platform_state(STATE_UNKNOWN)
 
-        # Must return None, not STATE_UNKNOWN.
-        #
-        # The caller is async_local_push in entities.py, not Home Assistant:
-        #
-        #     state = await self._async_update_validate_platform_state(state)
-        #     if not state is None:
-        #         setattr(self, self._state_attr, state)   # _attr_native_value
-        #         self.async_write_ha_state()
-        #
-        # _state_attr is '_attr_native_value' for sensors, so returning
-        # STATE_UNKNOWN puts the string straight back one line after this
-        # method guarded against it, and async_write_ha_state then raises
-        # ValueError for a numeric device class. Returning None makes the
-        # caller skip both the setattr and the write.
+        # None makes async_local_push skip its setattr and async_write_ha_state
         assert result is None
-        # And the string must never reach the stored value.
         assert not isinstance(s._attr_native_value, str)
 
     async def test_valid_numeric_state_updates_native_value(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -85,10 +85,22 @@ class TestSensorStateValidation:
 
         result = await s._async_update_validate_platform_state(STATE_UNKNOWN)
 
-        # Return value is STATE_UNKNOWN (HA uses this)
-        assert result == STATE_UNKNOWN
-        # But the stored native_value must NOT have been overwritten with the string
-        assert s._attr_native_value == 9999
+        # Must return None, not STATE_UNKNOWN.
+        #
+        # The caller is async_local_push in entities.py, not Home Assistant:
+        #
+        #     state = await self._async_update_validate_platform_state(state)
+        #     if not state is None:
+        #         setattr(self, self._state_attr, state)   # _attr_native_value
+        #         self.async_write_ha_state()
+        #
+        # _state_attr is '_attr_native_value' for sensors, so returning
+        # STATE_UNKNOWN puts the string straight back one line after this
+        # method guarded against it, and async_write_ha_state then raises
+        # ValueError for a numeric device class. Returning None makes the
+        # caller skip both the setattr and the write.
+        assert result is None
+        # And the string must never reach the stored value.
         assert not isinstance(s._attr_native_value, str)
 
     async def test_valid_numeric_state_updates_native_value(self):


### PR DESCRIPTION
Follow-up to #118, which is merged but whose `STATE_UNKNOWN` guard does not take effect.

## The guard is bypassed one line later

`_async_update_validate_platform_state` stops the assignment, but still **returns** `STATE_UNKNOWN`. The caller is `async_local_push` in `entities.py`:

```python
state = await self._async_update_validate_platform_state(state)
if not state is None:
    setattr(self, self._state_attr, state)   # _attr_native_value for sensors
    self.async_write_ha_state()              # raises here
```

`_state_attr` is `'_attr_native_value'`, so the string goes straight back into the field the guard just protected, and the write raises:

```
Sensor sensor.wattpilot_charger_temp has device class 'temperature', state class
'None' unit '°C' ... however, it has the non-numeric value: 'unknown' (<class 'str'>)
```

## Measured, not inferred

On an 11 kW charger (firmware 43.4, HA 2026.9.1) whose `tma` yields no usable value:

| | ValueErrors |
|---|---|
| before #118 | ~15/min |
| **with #118's guard** | **~15/min — unchanged** |
| returning `None` | **0** |

## Fix

Return `None` so the caller skips both the `setattr` and the write, and set `_attr_native_value = None` rather than leaving a stale reading — `None` is how Home Assistant represents "no value" for a numeric sensor.

## The existing test asserted the broken contract

```python
# Return value is STATE_UNKNOWN (HA uses this)
assert result == STATE_UNKNOWN
```

Home Assistant is not the caller; `async_local_push` is. That comment is why the bug survived review. The test now asserts `result is None` and quotes the call site inline, so the reasoning is visible at the point of the assertion.

42/42 tests pass.

## Note

This is independent of #122, #123 and #125 and touches different files, so it can be reviewed and merged on its own.

