### PR TITLE
Raise ConfigEntryNotReady when the charger is not reachable at setup

### DIFF
--- a/custom_components/wattpilot/__init__.py
+++ b/custom_components/wattpilot/__init__.py
@@ -6,6 +6,7 @@ import logging
 import asyncio
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_PARAMS
 from homeassistant.loader import async_get_integration
@@ -55,11 +56,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try: 
         _LOGGER.debug("%s - async_setup_entry: Connecting charger", entry.entry_id)
         charger = await async_ConnectCharger(entry.entry_id, entry.data)
-        if charger == False: return False 
+        # not ready rather than failed, so HA retries instead of giving up -
+        # after a power cut HA boots before the charger does
+        if charger == False:
+            raise ConfigEntryNotReady("charger not reachable yet")
+    except ConfigEntryNotReady:
+        raise
     except Exception as e:
         _LOGGER.error("%s - async_setup_entry: Connecting charger failed: %s (%s.%s)", entry.entry_id, str(e), e.__class__.__module__, type(e).__name__)
         async_DisconnectCharger(entry.entry_id, charger)
-        return False
+        raise ConfigEntryNotReady(str(e)) from e
 
     try:
         _LOGGER.debug("%s - async_setup_entry: Creating data store: %s.%s ", entry.entry_id, DOMAIN, entry.entry_id)


### PR DESCRIPTION
After a power cut, Home Assistant boots before the charger does. `async_ConnectCharger` times out, `async_setup_entry` returns `False`, and the entry lands in `setup_error` — which HA never retries. The integration then stays dead until the entry is reloaded by hand.

Observed on an 11 kW charger (HA 2026.9.2):

```
08:15:17  HA starting
08:15:50  async_ConnectCharger: Timeout - charger not connected
08:16:49  HA initialized
08:17:15  Websocket connected
08:17:16  Authentication successful
```

The websocket was connected and authenticated 90 s later, but all 49 entities stayed `unavailable` because the entry was already `setup_error`. A manual reload fixed it immediately.

Raising `ConfigEntryNotReady` instead makes HA retry with backoff, which is the documented pattern for a device that is not reachable yet.

One file touched, `__init__.py`; 42/42 tests pass.
