### PR TITLE
Do not mark properties initialized while fullStatus is still streaming

### DIFF
--- a/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
+++ b/custom_components/wattpilot/wattpilot/src/wattpilot/__init__.py
@@ -550,7 +550,10 @@ class Wattpilot(object):
             _LOGGER.error("Authentication failed: %s" , message.message)
 
     def __on_DeltaStatus(self,message):
-        self._allPropsInitialized=True # Assume all properties have been initialized when first delta status is received
+        # only when the charger never reports 'partial'; otherwise a delta
+        # arriving mid-fullStatus would mark init complete too early
+        if self.__allPropsInitializedFallback:
+            self._allPropsInitialized=True
         props = message.status.__dict__
         for key in props:
             self.__update_property(key,props[key])
@@ -628,6 +631,7 @@ class Wattpilot(object):
         self._connected = False
         self._allProps={}
         self._allPropsInitialized=False
+        self.__allPropsInitializedFallback=False
         self._voltage1=None
         self._voltage2=None
         self._voltage3=None


### PR DESCRIPTION
`__on_DeltaStatus` sets `_allPropsInitialized` unconditionally:

```python
def __on_DeltaStatus(self,message):
    self._allPropsInitialized=True  # Assume all properties have been initialized when first delta status is received
```

The charger sends `fullStatus` in chunks (`partial: true`, final `partial: false`) and interleaves live `deltaStatus` messages. A delta arriving mid-stream therefore marks initialization complete early, `async_ConnectCharger` returns, and entities are built against an incomplete `allProps`.

Observed on an 11 kW charger after a power cut:

```
08:23:20.178  Authentication successful
08:23:21.377  setup 9 switch entities
08:23:21.379  setup 10 number entities
```

`ebe`, `ebo`, `ebt`, `pdte` and `pdt` all failed `__init__` with *"Charger does not have a property"*. They arrive late in the stream. `_init_failed` is permanent, so the five Boost / PV-battery entities stayed `unavailable` until the entry was reloaded, even though the properties were present in `allProps` moments later.

The fix only lets a delta set the flag when the charger never reports `partial` — which is what `__allPropsInitializedFallback` appears to have been intended for. It is currently assigned in `__on_FullStatus` but never read, and never initialized in `__init__`.

Verified both paths:

| | after partial chunk | after mid-stream delta | after final fullStatus |
|---|---|---|---|
| reports `partial` | False | **False** (was True) | True |
| never reports `partial` | False | **True** (fallback preserved) | — |

42/42 tests pass.